### PR TITLE
Add LiveUpdateOverlay Component Type Definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { Ref, ComputedRef } from 'vue';
+import { Ref, ComputedRef, Component } from 'vue';
 
 export interface DebugInfo {
     status: Ref<string>;
@@ -27,9 +27,19 @@ export interface UseLiveUpdateReturn {
     debugInfo: DebugInfo;
 }
 
+export interface LiveUpdateOverlayProps {
+    liveUpdate: UseLiveUpdateReturn;
+}
+
 /**
  * Initializes the live update system with a WebSocket connection.
  * @param director - The WebSocket IP endpoint (host:port) to connect to.
  * @returns The live update API including status, subscribe, autoSubscribe, and debugInfo.
  */
 export function useLiveUpdate(director: string): UseLiveUpdateReturn;
+
+/**
+ * A Vue component that displays the connection status and provides reconnection functionality.
+ * @param props - Component props including the liveUpdate instance
+ */
+export const LiveUpdateOverlay: Component<LiveUpdateOverlayProps>; 


### PR DESCRIPTION
This pull request adds type definitions for the `LiveUpdateOverlay` component to the `@disguise-one/vue-liveupdate` package.

## Changes
- Added `LiveUpdateOverlayProps` interface to define the component's props
- Added `LiveUpdateOverlay` component export with proper TypeScript types
- Added JSDoc documentation for the component
- Imported `Component` type from Vue for proper component typing

## Why
The `LiveUpdateOverlay` component exists in the package but is not properly exported in the type definitions. This causes TypeScript errors when trying to import and use the component directly from the package.

## Testing
The changes have been tested with:
- TypeScript compilation
- Vue 3 component usage
- Integration with the `useLiveUpdate` composable

## Example Usage
```typescript
import { useLiveUpdate, LiveUpdateOverlay } from '@disguise-one/vue-liveupdate'

const liveUpdate = useLiveUpdate('localhost:8080')

// In template:
<LiveUpdateOverlay :liveUpdate="liveUpdate" />
```

## Related Issues
- Fixes TypeScript errors when importing LiveUpdateOverlay
- Improves package type safety
- Makes the component more discoverable through TypeScript intellisense