### PR TITLE
Used scoped style in LiveUpdateOverlay to avoid leaking button style

### DIFF
--- a/src/components/LiveUpdateOverlay.vue
+++ b/src/components/LiveUpdateOverlay.vue
@@ -26,7 +26,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Unscoped css and use of `button` element styling caused all buttons on page to inherit the button style in LiveUpdateOverlay 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal styling implementation for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->