### PR TITLE
Add support for updateFrequencyMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ export default {
 
 #### Configuration Options
 
-Both `useLiveUpdate` and individual subscriptions accept an optional configuration object. Currently, the configuration object supports the `updateFrequencyMs` property to control how often updates are sent from the server.
+Both `useLiveUpdate` and individual subscriptions accept an optional configuration object. Currently, the configuration object supports the `updateFrequencyMs` property to control how often updates are sent from the server. The default, and highest, frequency is 50ms.
 
 **Global Configuration**: Provide a configuration object to `useLiveUpdate` to set defaults for all subscriptions:
 
@@ -121,7 +121,7 @@ const { offset } = liveUpdate.subscribe(
   { updateFrequencyMs: 500 }
 );
 
-// This subscription uses whatever default was set (or no throttling if none)
+// This subscription uses whatever set in `useLiveUpdate` (or the default, if unset)
 const { rotation } = liveUpdate.autoSubscribe('screen2:surface_1', ['object.rotation']);
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ export default {
 
 `subscribe` provides full control over the local name of the dictionary subscription. Both methods are otherwise identical.
 
+#### Configuration Options
+
+Both `useLiveUpdate` and individual subscriptions accept an optional configuration object. Currently, the configuration object supports the `updateFrequencyMs` property to control how often updates are sent from the server.
+
+**Global Configuration**: Provide a configuration object to `useLiveUpdate` to set defaults for all subscriptions:
+
+```javascript
+// All subscriptions will update at most once per second by default
+const liveUpdate = useLiveUpdate(directorEndpoint, { updateFrequencyMs: 1000 });
+```
+
+**Per-Subscription Configuration**: Pass a configuration object to `subscribe` or `autoSubscribe` to override the default:
+
+```javascript
+// This subscription updates at most twice per second (overriding any default)
+const { offset } = liveUpdate.subscribe(
+  'screen2:surface_1', 
+  { offset: 'object.offset' },
+  { updateFrequencyMs: 500 }
+);
+
+// This subscription uses whatever default was set (or no throttling if none)
+const { rotation } = liveUpdate.autoSubscribe('screen2:surface_1', ['object.rotation']);
+```
+
 ### Component: `LiveUpdateOverlay`
 
 The `LiveUpdateOverlay` component displays an overlay when the WebSocket connection is not active.

--- a/src/composables/useLiveUpdate.js
+++ b/src/composables/useLiveUpdate.js
@@ -15,13 +15,20 @@ export function useLiveUpdate(director, config = {}) {
         throw new Error("'director' parameter is required.");
     }
 
-    // Validate configuration parameters
-    const allowedConfigKeys = ['updateFrequencyMs'];
-    const invalidKeys = Object.keys(config).filter(key => !allowedConfigKeys.includes(key));
-    if (invalidKeys.length > 0) {
-        console.error(`Invalid configuration keys: ${invalidKeys.join(', ')}. Allowed keys: ${allowedConfigKeys.join(', ')}`);
-        throw new Error(`Invalid configuration keys: ${invalidKeys.join(', ')}`);
+    // Validate configuration helper function
+    function validateConfiguration(configuration, context = 'configuration') {
+        if (!configuration) return;
+        
+        const allowedConfigKeys = ['updateFrequencyMs'];
+        const invalidKeys = Object.keys(configuration).filter(key => !allowedConfigKeys.includes(key));
+        if (invalidKeys.length > 0) {
+            console.error(`Invalid ${context} keys: ${invalidKeys.join(', ')}. Allowed keys: ${allowedConfigKeys.join(', ')}`);
+            throw new Error(`Invalid ${context} keys: ${invalidKeys.join(', ')}`);
+        }
     }
+
+    // Validate global configuration
+    validateConfiguration(config, 'configuration');
 
     // Initialize the WebSocket connection & provide reactive data.
     const socketUrl = `ws://${director}/api/session/liveupdate`;
@@ -107,14 +114,7 @@ export function useLiveUpdate(director, config = {}) {
         const properties = Object.values(refNameToPropertyPaths);
         
         // Validate per-subscription configuration parameters
-        if (configuration) {
-            const allowedConfigKeys = ['updateFrequencyMs'];
-            const invalidKeys = Object.keys(configuration).filter(key => !allowedConfigKeys.includes(key));
-            if (invalidKeys.length > 0) {
-                console.error(`Invalid subscription configuration keys: ${invalidKeys.join(', ')}. Allowed keys: ${allowedConfigKeys.join(', ')}`);
-                throw new Error(`Invalid subscription configuration keys: ${invalidKeys.join(', ')}`);
-            }
-        }
+        validateConfiguration(configuration, 'subscription configuration');
         
         // Merge default configuration with per-subscription configuration
         const mergedConfiguration = { ...config, ...configuration };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,10 +21,6 @@ export interface SubscriptionConfiguration {
     updateFrequencyMs?: number;
 }
 
-export interface UseLiveUpdateConfiguration {
-    updateFrequencyMs?: number;
-}
-
 export interface SubscriptionValue extends ComputedRef<any> {
     isFrozen: () => boolean;
     freeze: () => void;
@@ -58,7 +54,7 @@ export interface LiveUpdateOverlayProps {
  * @param config - Optional configuration object with default settings.
  * @returns The live update API including status, subscribe, autoSubscribe, and debugInfo.
  */
-export function useLiveUpdate(director: string, config?: UseLiveUpdateConfiguration): UseLiveUpdateReturn;
+export function useLiveUpdate(director: string, config?: SubscriptionConfiguration): UseLiveUpdateReturn;
 
 /**
  * A Vue component that displays the connection status and provides reconnection functionality.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,14 @@ export interface Subscription {
     propertyPath: string;
 }
 
+export interface SubscriptionConfiguration {
+    updateFrequencyMs?: number;
+}
+
+export interface UseLiveUpdateConfiguration {
+    updateFrequencyMs?: number;
+}
+
 export interface SubscriptionValue extends ComputedRef<any> {
     isFrozen: () => boolean;
     freeze: () => void;
@@ -29,11 +37,13 @@ export interface UseLiveUpdateReturn {
     reconnect: () => void;
     subscribe: (
         objectPath: string,
-        refNameToPropertyPaths: Record<string, string>
+        refNameToPropertyPaths: Record<string, string>,
+        configuration?: SubscriptionConfiguration
     ) => Record<string, SubscriptionValue>;
     autoSubscribe: (
         objectPath: string,
-        propertyPaths: string[]
+        propertyPaths: string[],
+        configuration?: SubscriptionConfiguration
     ) => Record<string, SubscriptionValue>;
     debugInfo: DebugInfo;
 }
@@ -45,9 +55,10 @@ export interface LiveUpdateOverlayProps {
 /**
  * Initializes the live update system with a WebSocket connection.
  * @param director - The WebSocket IP endpoint (host:port) to connect to.
+ * @param config - Optional configuration object with default settings.
  * @returns The live update API including status, subscribe, autoSubscribe, and debugInfo.
  */
-export function useLiveUpdate(director: string): UseLiveUpdateReturn;
+export function useLiveUpdate(director: string, config?: UseLiveUpdateConfiguration): UseLiveUpdateReturn;
 
 /**
  * A Vue component that displays the connection status and provides reconnection functionality.


### PR DESCRIPTION
Allows either a global override or per subscription update frequency.

I think it would be useful for the subscription response to also include the configuration parameters otherwise they need to be cached for re-subscription and freeze/thaw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional global and per-subscription configuration for live updates (e.g., updateFrequencyMs)
  * subscribe and autoSubscribe accept per-subscription configuration; per-subscription settings override defaults and persist across reconnects

* **Tests**
  * Added tests verifying configuration propagation, default handling, overrides, validation, and freeze/thaw behavior

* **Documentation**
  * Added Configuration Options docs with examples for global defaults and per-subscription overrides

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->